### PR TITLE
【管理コンソール】とあるロールユーザ(自分自身)のロール―・ユーザー紐付を廃止したら「システムエラー」になる #897

### DIFF
--- a/ita_install_package/ITA/ita-contents/ita-root/webroot/default/menu/00_javascript.js
+++ b/ita_install_package/ITA/ita-contents/ita-root/webroot/default/menu/00_javascript.js
@@ -151,6 +151,13 @@ callback.prototype = {
             objAlertArea.innerHTML = ary_result[2];
             objAlertArea.style.display = "block";
         }else{
+            // 自身の権限を廃止した直後、表示権限がない場合にエラーメッセージが返ってくるのでDASHBOARDを表示する
+            var exp = new RegExp("^<script.*?>alert\\('(.*?)'\\);</script>ss\\d*?;redirectOrderForHADACClientss\\d*?;1ss\\d*?;(.*)$").exec(result);
+            if ( exp != null && Array.isArray(exp) && exp.length == 3 ){
+                window.alert(exp[1]);
+                location.href = exp[2];
+                return;
+            }
             window.alert(getSomeMessage("ITAWDCC90101"));
         }
         showForDeveloper(result);


### PR DESCRIPTION
【管理コンソール】とあるロールユーザ(自分自身)のロール―・ユーザー紐付を廃止したら「システムエラー」になる
* 当該メニューは2100000210
* 廃止はproxy.Mix1_1_deleteTableで呼ばれ、callback.prototype['Mix1_1_deleteTable']に処理が戻ってくる
  * その際ary_result[0] == "000"、ary_result[1] == "210"なので、「// エラーなく廃止完了」とコメントのある行に落ちる
    * case "210":にはbreak構文がないためcase "100":が流れで実施される
    * その中でsearch_async()を呼び、最後のproxy.Filter1Tbl_recCountが呼ばれる
    * この先は最初と同様にcallback.prototype['Filter1Tbl_recCount']が呼ばれ、ここでエラーが発生している
      * エラーとなった際のcallback関数の引数(つまり同名のphp関数の戻り値)内部を確認したところ、エラーメッセージのalertダイアログ出力スクリプトとredirectの命令文が書かれていた
        * これは関数の名前の通り件数カウント用の関数だが、この時点で権限がないためエラーが戻ってきている。
        * proxyで呼ぶ関数内ではこのようなHTML表示前提のエラーメッセージを返しても仕方がないが、これは今回の件と関係ない大部分がそのような処理になっているため、そのままとする
        * とはいえ、せっかくエラーメッセージが出力されているものを利用しない手はないので、通常のエラーと判別できるよう正規表現にて「エラーメッセージのalertダイアログ出力スクリプトとredirectの命令文が書かれているか」を判定した上で、エラーメッセージをalert出力し、リダイレクト先に飛ばすように実装した
        * このロジックは汎用と思われるので、個別メニューID用のJSファイルを新規作成せず、デフォルトのJSファイルに処理を追加した